### PR TITLE
Issues #1, #2 and #4 fixed.

### DIFF
--- a/src/feature.js
+++ b/src/feature.js
@@ -179,9 +179,11 @@ tnt_feature.composite = function () {
 
     var reset = function () {
     	var track = this;
-    	for (var i=0; i<displays.length; i++) {
-    	    displays[i].reset.call(track);
-    	}
+        for (var display in displays) {
+            if (displays.hasOwnProperty(display)) {
+                displays[display].reset.call(track);
+            }
+        }
     };
 
     var init = function (width) {

--- a/src/feature.js
+++ b/src/feature.js
@@ -768,7 +768,6 @@ tnt_feature.axis = function () {
     feature.reset = function () {
     	xAxis = undefined;
     	var track = this;
-    	track.g.selectAll("rect").remove();
     	track.g.selectAll(".tick").remove();
     };
     feature.plot = function () {};

--- a/src/feature.js
+++ b/src/feature.js
@@ -823,6 +823,8 @@ tnt_feature.location = function () {
     feature.plot = function () {};
     feature.init = function () {
         row = undefined;
+        var track = this;
+        track.g.select("text").remove();
     };
     feature.mover = function() {
     	var domain = xScale.domain();


### PR DESCRIPTION
Problems removed:
Issue #1: Every time board was resized, the old text element wasn't removed and a new one was appended in location feature.
Issue #2: Display which is an object was iterated as an array which didn't work and consequently old elements weren't removed from the track in reset function in composite feature.
Issue #4: In axis feature, rect element was removed in reset function, so the background kept disappearing when the board was resized.

I also looked into Issue #3 and I located the problem, but I didn't know how (and whether) you would like to solve that. Actually, now the problem is a bit different as fixing issue #2 changed it a bit - now only one line/area stays and the rest is removed on resize. In create function in line and area features, all the path elements within a track are removed, so only the last one to be rendered will stay on the screen. But as all the elements from different features are children of <g> track element and don't have any classes/ids, it's not really possible to distinguish between different lines/areas within one track. A solution could be to put every feature from a composite feature into a separate <g> (and maybe with class as the feature key given in the retriever) which would be placed as children of <g> track element.