### PR TITLE
Change default domain of pin feature from [0,0] to [0,1]

### DIFF
--- a/src/feature.js
+++ b/src/feature.js
@@ -570,7 +570,7 @@ tnt_feature.pin = function () {
     var opts = {
         pos : d3.functor("pos"),
         val : d3.functor("val"),
-        domain : [0,0]
+        domain : [0,1]
     };
 
     var pin_ball_r = 5; // the radius of the circle in the pin


### PR DESCRIPTION
Corresponding to the [documentation](http://tntvis.github.io/tnt.board/api/board/index.html#pin.domain) which says that the default domain is [0,1].